### PR TITLE
Support custom path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ The formatter is not perfect yet, so `:MixFormatDiff` will open a diff window
 that can be used for previewing the changes or picking only those that seem
 reasonable.
 
+If you're not using Elixir 1.6 in your project, but want to be able to use `mix
+format`, you can specify a specific path for the elixir executable as such:
+
+```vim
+let g:mix_format_elixir_path = '~/path/to/elixir'
+```
+
 ![demo](demo.gif)
 
 `dp` pushes changes from the diff window to the source file. `q` closes the diff

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -2,6 +2,10 @@ if exists('b:loaded_mix_format') || &compatible
   finish
 endif
 
+if !exists('g:mix_format_elixir_path')
+  let g:mix_format_elixir_path = ''
+endif
+
 function! s:on_stdout_nvim(_job, data, _event) dict abort
   if empty(a:data[-1])
     " Second-last item is the last complete line in a:data.
@@ -84,11 +88,23 @@ function! s:on_exit(_job, exitval, ...) dict abort
 endfunction
 
 function! s:get_cmd_from_file(filename) abort
-  let cmd = 'mix format '. shellescape(a:filename)
+  let l:cmd = build_cmd(a:filename)
+
   if has('win32') && &shell =~ 'cmd'
-    return cmd
+    return l:cmd
   endif
-  return ['sh', '-c', cmd]
+  return ['sh', '-c', l:cmd]
+endfunction
+
+function! s:build_cmd(filename) abort
+  let l:path = get(g:, 'mix_format_elixir_path')
+  let l:base_cmd = 'mix format '
+
+  if l:path ==? ''
+    let l:cmd = l:base_cmd . shellescape(a:filename)
+  else
+    let l:cmd = l:path .'/bin/elixir '. l:path . '/bin/'. l:base_cmd . shellescape(a:filename)
+  end
 endfunction
 
 function! s:mix_format(diffmode) abort

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -88,7 +88,7 @@ function! s:on_exit(_job, exitval, ...) dict abort
 endfunction
 
 function! s:get_cmd_from_file(filename) abort
-  let l:cmd = build_cmd(a:filename)
+  let l:cmd = s:build_cmd(a:filename)
 
   if has('win32') && &shell =~ 'cmd'
     return l:cmd
@@ -104,7 +104,8 @@ function! s:build_cmd(filename) abort
     let l:cmd = l:base_cmd . shellescape(a:filename)
   else
     let l:cmd = l:path .'/bin/elixir '. l:path . '/bin/'. l:base_cmd . shellescape(a:filename)
-  end
+  endif
+  return l:cmd
 endfunction
 
 function! s:mix_format(diffmode) abort


### PR DESCRIPTION
### Context

I'm working on a few elixir projects, but none of them are using 1.6 yet, so I wanted to figure out a way I could use `mix format` without breaking things. The changes I'm making will allow the user to set a path for the `elixir` executable, instead of relying on the default for that folder.

(This is my first contribution to a plugin, sorry if something in the code/PR is not correct - I'll promptly fix them when pointed out 😃 )