### PR TITLE
Implement option to not auto show format errors

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -27,10 +27,17 @@ endfunction
 
 function! s:on_exit(_job, exitval, ...) dict abort
   if a:exitval
-    execute len(self.stdout) > 14 ? 14 : len(self.stdout) 'new'
-    set buftype=nofile
-    put =join(self.stdout, \"\n\")
-    1delete
+    if get(g:, 'mix_format_silent_errors')
+      for line in self.stdout
+        echomsg line
+      endfor
+    else
+      execute len(self.stdout) > 14 ? 14 : len(self.stdout) 'new'
+      set buftype=nofile
+      put =join(self.stdout, \"\n\")
+     1delete
+    endif
+
     echohl ErrorMsg
     echomsg 'Failed: '. self.cmd
     echohl NONE

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -35,7 +35,7 @@ function! s:on_exit(_job, exitval, ...) dict abort
       execute len(self.stdout) > 14 ? 14 : len(self.stdout) 'new'
       set buftype=nofile
       put =join(self.stdout, \"\n\")
-     1delete
+      1delete
     endif
 
     echohl ErrorMsg


### PR DESCRIPTION
Implemented a `g:mix_format_silent_errors` option to not automatically open the format errors window (statusline part is still shown) since I found out that most of the time I knew what I did wrong anyways and it was more annoying than helpful at that point.

If the option is enabled you can still see the errors by using `:messages`.

Tested in Neovim.