### PR TITLE
Do not format .leex files

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -1,5 +1,5 @@
 if exists('b:loaded_mix_format')
-      \ || index(['eex', 'leex'], fnamemodify(expand('%'), ':e')) >= 0
+      \ || &filetype != 'elixir'
       \ || &compatible
   finish
 endif

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -1,5 +1,5 @@
 if exists('b:loaded_mix_format')
-      \ || fnamemodify(expand('%'), ':e') == 'eex'
+      \ || index(['eex', 'leex'], fnamemodify(expand('%'), ':e')) >= 0
       \ || &compatible
   finish
 endif


### PR DESCRIPTION
@mhinz It might be better to explicitly only format `.ex`/`.exs` files, instead of blacklisting extensions.