### PR TITLE
Show errors in current buffer window instead of the global quickfix window

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -62,9 +62,9 @@ function! s:on_exit(_job, exitval, ...) dict abort
   let old_efm = &errorformat
   let &errorformat  = '%-Gmix format failed%.%#'
   let &errorformat .= ',** (%.%#) %f:%l: %m'
-  cgetexpr self.stdout
+  lgetexpr self.stdout
   let &errorformat = old_efm
-  cwindow
+  lwindow
   if &buftype == 'quickfix'
     let w:quickfix_title = s:build_cmd(fnamemodify(self.origfile, ':.'))
   endif


### PR DESCRIPTION
Since formatting works only on the current buffer, it could be argued that formatting errors should be displayed in the current buffer window instead of the global quickfix window. (Because the global quickfix window may already be displaying other information, e.g. project-wide search results, that is lost when formatting errors are loaded into it.)