### PR TITLE
Use :cd (not :lcd) to go in and out of the mix dir

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -43,7 +43,7 @@ function! s:on_exit(_job, exitval, ...) dict abort
   call win_gotoid(self.win_id)
 
   call s:msg(self.verbose, 'Changing to: '. self.origdir)
-  execute 'lcd' fnameescape(self.origdir)
+  execute 'cd' fnameescape(self.origdir)
 
   if filereadable(self.undofile)
     execute 'silent rundo' self.undofile
@@ -174,7 +174,7 @@ function! s:mix_format(diffmode) abort
   else
     let mixroot = fnamemodify(mixfile, ':h')
     call s:msg(&verbose, 'Changing to: '. mixroot)
-    execute 'lcd' fnameescape(mixroot)
+    execute 'cd' fnameescape(mixroot)
   endif
 
   let origfile = expand('%')


### PR DESCRIPTION
:lcd has a side-effect on the window in which it was executed: any changes to the working directory that may get executed in other windows will not have an effect on this window because it now has its own private current working directory. When multiple windows/splits/tabs are in play, the use of :lcd to temporarily change current working directory leads to confusion. This happens because it is not in fact a temporary change - i.e. it leaves a mark.

Setup:

```
:cd directory_ABC
:edit file_A
:vsplit file_B
```

Now:

1. go to `file_A` split window
2. mix-format `file_A` as you would
3. go to `file_B` split window
4. `:cd directory_XYZ`
5. return to `file_A` split window
6. `:pwd`

Question: what do you expect `:pwd` to report in step 6?

If you're like me, the answer is probably `directory_XYZ` - after all, didn't we just do a global `:cd directory_XYZ` in step 4? Would you be surprised to find that the actual answer is `directory_ABC`? I was :)

The reason for this disconnect is that `vim-mix-format` currently uses `lcd` to change into and out of the mix project directory. But `lcd` is sticky - it sticks to the window in which it was invoked, overriding any further global `:cd` executed from other windows.

I have a feeling this was not the intent of using `lcd` here - I think it was actually used defensively, to keep the directory change as local as possible in case something goes wrong. But ironically it is actually accomplishing the opposite effect - executing mix-format causes a "permanent" side-effect in the vim window/split in which it was executed, even on the happy path.
