### PR TITLE
Use 'cwd' for jobs (take two)

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -224,12 +224,12 @@ function! s:mix_format(diffmode) abort
           \ }))
   else
     silent! call job_stop(s:id)
-    let s:id = job_start(cmd, {
+    let s:id = job_start(cmd, extend({
           \ 'in_io':   'null',
           \ 'err_io':  'out',
           \ 'out_cb':  function('s:on_stdout_vim', options),
           \ 'exit_cb': function('s:on_exit', options),
-          \ })
+          \ }, has_key(options, 'cwd') ? {'cwd': options.cwd} : {}))
   endif
 endfunction
 


### PR DESCRIPTION
@mhinz I noticed an issue with https://github.com/mhinz/vim-mix-format/commit/03ecf6d565c569b0a8de480467dc0a2c4c9e81a9

`cwd` works in the `if has('nvim')` branch, but it doesn't work in the `else` branch because `options` is not actually used there (other than as a second argument to `out_cb` and `exit_cb`, but I can't wrap my head around what that does).

We cannot `extend` options in the `else` branch because vim will complain about invalid (for vim as opposed to nvim) arguments contained in `options`, so I did something else here - let me know if there's a cleaner way...

Thanks as always!