### PR TITLE
return --dot-formatter option

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -147,6 +147,10 @@ function! s:build_cmd(filename) abort
   let options = get(g:, 'mix_format_options', '--check-equivalent')
 
   let [shellslash, &shellslash] = [&shellslash, 0]
+  let dot_formatter = findfile('.formatter.exs', expand('%:p:h').';')
+  if !empty(dot_formatter)
+    let options .= ' --dot-formatter '. shellescape(dot_formatter)
+  endif
   let filename = shellescape(a:filename)
   let &shellslash = shellslash
 


### PR DESCRIPTION
after it was removed in [03ecf6d](https://github.com/mhinz/vim-mix-format/commit/03ecf6d565c569b0a8de480467dc0a2c4c9e81a9#diff-b5b7fe73f303b12041f70e1ebf572609L145), umbrella projects stopped
picking up .formatter.exs located in umbrella root dir when saving file
in apps/some_app/some_file.ex

