### PR TITLE
fix path to .formatter.exs file

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -147,7 +147,7 @@ function! s:build_cmd(filename) abort
   let options = get(g:, 'mix_format_options', '--check-equivalent')
 
   let [shellslash, &shellslash] = [&shellslash, 0]
-  let dot_formatter = findfile('.formatter.exs', expand('%:p:h').';')
+  let dot_formatter = fnamemodify(findfile('.formatter.exs', expand('%:p:h').';'), ':p')
   if !empty(dot_formatter)
     let options .= ' --dot-formatter '. shellescape(dot_formatter)
   endif


### PR DESCRIPTION
Sorry I hurried with pull request #31

use absolute path to .formatter.exs file in jobs with cwd