### PR TITLE
Maintain folds after file is formatted

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -92,14 +92,14 @@ function! s:on_exit(_job, exitval, ...) dict abort
       return
     endif
   else
-    let [fdl, sol, ur] = [&foldlevel, &startofline, &undoreload]
+    let [sol, ur] = [&startofline, &undoreload]
     let [&startofline, &undoreload] = [0, 10000]
-    let view = winsaveview()
+    mkview
     try
       silent edit!
     finally
-      call winrestview(view)
-      let [&foldlevel, &startofline, &undoreload] = [fdl, sol, ur]
+      let [&startofline, &undoreload] = [sol, ur]
+      loadview
     endtry
     call win_gotoid(source_win_id)
     return


### PR DESCRIPTION
This PR attempts to fix the situation where after the formatter is run and the file is reloaded the created folds would all be unfolded.

You can see it in action below. Notice how after running `:MixFormat` the fold for `foo/1` is not undone.

[![asciicast](https://asciinema.org/a/EcTGHP71nCKxy7OpropxBCL7r.svg)](https://asciinema.org/a/EcTGHP71nCKxy7OpropxBCL7r)

Here's a couple of points that might be worth considering:
* Replaced the call to `winsaveview` to a call to `mkview` because the former does not save fold information.
* Replaced call to `winrestview` with a call to `loadview` seeing as `winsaveview` is no longer used. 
* Removed the logic that saves and resets the `foldlevel` setting as I wasn't seeing it being changed. But this might be something wrong to do so please let me known and I'll rever the changes.

Feel free to suggest any changes 👍 