### PR TITLE
Allow :MixFormat command to run on eelixir filetype

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -1,6 +1,5 @@
 if exists('b:loaded_mix_format')
-      \ || &filetype != 'elixir'
-      \ || &filetype != 'eelixir'
+      \ || &filetype != ('elixir' || 'eelixir')
       \ || &compatible
   finish
 endif

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -1,5 +1,6 @@
 if exists('b:loaded_mix_format')
       \ || &filetype != 'elixir'
+      \ || &filetype != 'eelixir'
       \ || &compatible
   finish
 endif


### PR DESCRIPTION
## Overview

 With the `heex` formatter [being added to LiveView](https://github.com/phoenixframework/phoenix_live_view/blob/master/lib/phoenix_live_view/html_formatter.ex) it would be helpful to allow this plugin to run on those filetypes.

Connects [#42](https://github.com/mhinz/vim-mix-format/issues/42)

### Notes

- Until the new version of LiveView is released with this plugin built in you'll need to manually add it to your Elixir project: ` {:heex_formatter, github: "feliperenan/heex_formatter"}`
- If using the `vim-elixir` plugin, the filetype for `*.heex` files (should) be set to `eelixir`.
- This PR targets `eelixir` files. I could also see adding support specifically for `heex` filetype since that is the filetype that gets detected when not using the `vim-elixir` plugin.

## Testing Instructions

* [Update](https://github.com/phoenixframework/phoenix_live_view/blob/969d8634572a349df12fdde7aa4394d60ddcd127/lib/phoenix_live_view/html_formatter.ex#L9) your `.formatter.exs` to support `.heex` files
* Open a `*.heex` template in a new buffer
* Ensure the `:MixFormat` command is available and works as expected